### PR TITLE
Zoom window instead of resizing.

### DIFF
--- a/delivery-window-finder.applescript
+++ b/delivery-window-finder.applescript
@@ -294,14 +294,8 @@ if javascriptEnabled then
 				set miniaturized of window id amzn_win_id to false
 				-- wait for window to open
 				delay 1
-				-- maximize window 
-				-- this might be useful later on if I want to have it take a screenshot as proof of delivery slots found
-				-- Credit for fill to screen: https://macosxautomation.com/applescript/firsttutorial/18.html
-				tell application "System Events"
-					tell application "Finder" to get the bounds of the window of the desktop
-					tell application "Safari" to set the bounds of the front window to Â
-						{0, 22, (3rd item of the result), (4th item of the result)}
-				end tell
+				-- zoom window
+				set zoomed of window id amzn_win_id to false
 			end tell
 			
 			-- signals that the loop should end


### PR DESCRIPTION
First, thanks!  I got the two delivery slots I needed with your script.

I've got a Retina iMac with a 1920x1080 second monitor (non-Retina) to the right.  Given my particular configuration, the desktop on the second monitor is perhaps 60% as tall as the built-in display, I have to make windows shorter before moving them across.

When this script gets a slot, it unminimizes the window and resizes it to the desktop.  Unfortunately, on my system, that creates a giant, almost unusable window that extends across both monitors to the full height of the Retina display.  As I remember it, I clicked through to the confirm-order page, and the Amazon Buy button ended up hidden under my Notifications, and the zoom button was unhelpful since the window has actually been resized-- it just grows the window by a pixel or two to fill the entire screen.  I had to resize the window.  (But I still did get my slots.)

I'd like to suggest this change.  On my system, the window vertically zooms to full height and its width grows a bit.  The zoom button returns it to its previous size.  And it's simpler code.  I'm unclear on the full behavior of zoom, but I suspect it's intelligent enough to grow only to one display on multi-monitor systems.
